### PR TITLE
Add Idea Reality MCP to app registry

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -506,5 +506,48 @@
       }
     ],
     "setup": []
+  },
+  {
+    "name": "Idea Reality",
+    "description": "Pre-build reality check for AI coding agents. Scans GitHub, HN, npm, PyPI, and Product Hunt before you build — returns a 0-100 reality signal.",
+    "icon": {
+      "type": "url",
+      "url": {
+        "light": "https://avatars.githubusercontent.com/u/263367191?v=4",
+        "dark": "https://avatars.githubusercontent.com/u/263367191?v=4"
+      }
+    },
+    "category": "Utilities",
+    "price": "Free",
+    "developer": "Mnemox AI",
+    "sourceUrl": "https://github.com/mnemox-ai/idea-reality-mcp",
+    "config": {
+      "mcpKey": "idea-reality",
+      "runtime": "uvx",
+      "args": [
+        "idea-reality-mcp"
+      ]
+    },
+    "features": [
+      {
+        "name": "Reality check an idea",
+        "description": "Scan existing projects across GitHub, HN, npm, PyPI and Product Hunt before building",
+        "prompt": "Check if someone has already built a CLI tool for generating release announcements"
+      },
+      {
+        "name": "Deep market analysis",
+        "description": "Run comprehensive analysis across all 5 sources with detailed evidence",
+        "prompt": "idea_check 'AI-powered code review tool' depth=deep"
+      }
+    ],
+    "setup": [
+      {
+        "label": "GitHub Token (optional, for higher rate limits)",
+        "type": "input",
+        "value": "",
+        "placeholder": "ghp_xxxxxxxxxxxx",
+        "key": "GITHUB_TOKEN"
+      }
+    ]
   }
 ]


### PR DESCRIPTION
## Add Idea Reality MCP

**Pre-build reality check for AI coding agents.** Scans GitHub, HN, npm, PyPI, and Product Hunt before you build — returns a 0-100 reality signal.

### Details

- **Source:** [github.com/mnemox-ai/idea-reality-mcp](https://github.com/mnemox-ai/idea-reality-mcp)
- **PyPI:** [`idea-reality-mcp`](https://pypi.org/project/idea-reality-mcp/)
- **Runtime:** `uvx` (Python, installed via `uvx idea-reality-mcp`)
- **Category:** Utilities
- **Price:** Free
- **Developer:** Mnemox AI

### What it does

Idea Reality MCP provides an `idea_check` tool that scans 5 data sources (GitHub, Hacker News, npm, PyPI, Product Hunt) to assess market saturation before you start building. It returns a reality signal score from 0–100, existing similar projects as evidence, and pivot suggestions.

Two modes:
- **quick** (default): GitHub + HN — fast scan in ~2 seconds
- **deep**: All 5 sources in parallel — comprehensive market analysis

### Setup

Only requires an optional `GITHUB_TOKEN` for higher rate limits. Works without any tokens.