### PR TITLE
Add Proxygate

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -506,5 +506,28 @@
       }
     ],
     "setup": []
+  },
+  {
+    "name": "Proxygate",
+    "description": "Curated marketplace of real-world data APIs for AI agents. Browse listings and call any endpoint per request from one prepaid USDC balance on Solana, with seller keys injected server-side and a signed receipt per call.",
+    "icon": {
+      "type": "url",
+      "url": {
+        "light": "https://raw.githubusercontent.com/proxygate-official/mcp/main/logo.png",
+        "dark": "https://raw.githubusercontent.com/proxygate-official/mcp/main/logo.png"
+      }
+    },
+    "category": "Utilities",
+    "price": "Free",
+    "developer": "Proxygate",
+    "sourceUrl": "https://github.com/proxygate-official/mcp",
+    "config": {
+      "mcpKey": "proxygate",
+      "runtime": "npx",
+      "args": [
+        "mcp-remote",
+        "https://gateway.proxygate.ai/mcp"
+      ]
+    }
   }
 ]


### PR DESCRIPTION
Adds **Proxygate** to the registry.

Proxygate is a curated marketplace of real-world data APIs for AI agents: connect once and call any listing (market data, crypto, weather, geocoding, developer tools, and more) per request from one prepaid USDC balance on Solana. Seller keys are injected server-side and never exposed, and every call returns a signed receipt.

It is a remote MCP server (`https://gateway.proxygate.ai/mcp`, also in the official MCP Registry as `ai.proxygate/mcp`), bridged with `npx mcp-remote` so it works through Fleur's stdio config. Source + connection docs: https://github.com/proxygate-official/mcp
